### PR TITLE
Add support for return value inspection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+# command to install tox depdendency, which then knows how to install any other dependencies
+install: "pip install tox"
+# command to run tests
+script: tox

--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,24 @@ that has side effects:
     def foo(*args, **kwargs):
         pass
 
+**Decorating view functions**
+
+By default, the ``has_side_effects`` decorator will run so long as the inner
+function does not raise an exception. View functions, however, are a paticular
+case where the function may run, and return a perfectly valid ``HttpResponse``
+object, but you do **not** want the side effects to run, as the response object
+has a ``status_code`` of 404, 500, etc. In this case, you want to inspect the
+inner function return value before deciding whether to fire the side effects
+functions. In order to support this, the ``has_side_effects`` decorator has
+a kwarg ``run_on_exit`` which takes a function that takes a single parameter,
+the return value from the inner function, and must return ``True`` or ``False``
+which determines whether to run the side effects.
+
+The ``decorators`` module contains the default argument for this kwarg, a
+function called ``http_response_check``. This will return ``False`` if the
+inner function return value is an ``HttpResponse`` object with a status
+code in the 4xx-5xx range.
+
 
 The second decorator, ``is_side_effect_of``, is used to bind those functions
 that implement the side effects to the origin function:

--- a/side_effects/decorators.py
+++ b/side_effects/decorators.py
@@ -1,13 +1,23 @@
 # -*- coding: utf-8 -*-
 from functools import wraps
 
+from django.http import HttpResponse
+
 from .registry import (
     register_side_effect,
     run_side_effects
 )
 
 
-def has_side_effects(label):
+def http_response_check(response):
+    """Return True for anything other than 4xx, 5xx status_codes."""
+    if isinstance(response, HttpResponse):
+        return not (400 <= response.status_code < 600)
+    else:
+        return True
+
+
+def has_side_effects(label, run_on_exit=http_response_check):
     """
     Run decorated function and raise side_effects signal when complete.
 
@@ -23,10 +33,23 @@ def has_side_effects(label):
     module in core. You can use the label to call the appropriate side
     effect function.
 
+    The run_on_exit kwarg can be used for fine-grained control over the exact
+    behaviour required. The canonical use case for this is when decorating
+    view functions - as they will typically always return a valid HttpResponse
+    object, and use the status_code property to indicate whether the view
+    function ran OK.
+
     Args:
         label: string, an identifier that is used in the receiver to determine
             which event has occurred. This is required because the function name
             won't be sufficient in most cases.
+
+    Kwargs:
+        run_on_exit: function used to determine whether the side effects should
+            run, based on the return value of the innner function. This can be
+            used to inspect the result for fine grained control. The default is
+            `http_response_check`, which will return False for 4xx, 5xx status
+            codes.
 
     """
     def decorator(func):
@@ -34,7 +57,8 @@ def has_side_effects(label):
         def inner_func(*args, **kwargs):
             """Run the original function and send the signal if successful."""
             result = func(*args, **kwargs)
-            run_side_effects(label, *args, **kwargs)
+            if run_on_exit(result):
+                run_side_effects(label, *args, **kwargs)
             return result
         return inner_func
     return decorator

--- a/side_effects/tests.py
+++ b/side_effects/tests.py
@@ -127,6 +127,14 @@ class DecoratorTests(TestCase):
         func = decorators.has_side_effects('foo')(test_func_no_docstring)
         func('bar', kwarg1='baz')
         mock_run.assert_called_with('foo', 'bar', kwarg1='baz')
+        mock_run.reset_mock()
+        # forcible ignore the side effects via the run_on_exit kwarg
+        func = (
+            decorators.has_side_effects('foo', run_on_exit=lambda r: False)
+            (test_func_no_docstring)
+        )
+        func('bar', kwarg1='baz')
+        mock_run.assert_not_called()
 
     @mock.patch('side_effects.decorators.register_side_effect')
     def test_is_side_effect_of(self, mock_register):

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,15 @@
 [tox]
-envlist = django1{9,10}_py27
+envlist = py{27,34,35,36}-django1{9,10}
 
 [testenv]
+skip_missing_interpreters = True
 ignore_errors = True
-basepython = python2.7
 
 deps =
     coverage==4.2
     mock==2.0.0
-    django19_py27: Django>1.9,<1.10
-    django110_py27: Django>1.9,<1.11
+    django19: Django>1.9,<1.10
+    django110: Django>1.9,<1.11
 
 commands=
     coverage erase


### PR DESCRIPTION
This is a generic solution to the problem posed by view functions - the requirement to inspect the return value from a decorated function to determine whether to fire the side effects or not. The default implementation will **not** fire side effects if the inner function returns an `HttpResponse` object and that object has a status_code in the 4xx-5xx range. This behaviour can be overridden by passing a function as the `run_on_exit` kwarg to the `has_side_effects` decorator.

```python
def let_through_200_only(response):
   return response.status_code == 200

@has_side_effects('foobar', run_on_exit=let_through_200_only)
def view_runc(request)
    pass
```
  