### PR TITLE
Add disable_side_effects context manager and decorator

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ chdir(path.normpath(path.join(path.abspath(__file__), pardir)))
 
 setup(
     name="django-side-effects",
-    version="1.0.2",
+    version="1.1",
     packages=find_packages(),
     include_package_data=True,
     description='Django app for managing external side effects.',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ chdir(path.normpath(path.join(path.abspath(__file__), pardir)))
 
 setup(
     name="django-side-effects",
-    version="1.0.1",
+    version="1.0.2",
     packages=find_packages(),
     include_package_data=True,
     description='Django app for managing external side effects.',

--- a/side_effects/settings.py
+++ b/side_effects/settings.py
@@ -2,15 +2,16 @@ from env_utils import get_bool
 
 from django.conf import settings
 
-# If True then do not raise exceptions caught when running
-# side-effects, but just log them instead.
-# Default = True
-SUPPRESS_ERRORS = getattr(
-    settings, 'SIDE_EFFECTS_SUPPRESS_ERRORS',
-    get_bool('SIDE_EFFECTS_SUPPRESS_ERRORS', True)
+# If True then instead of logging exceptions in side-effects
+# functions, raise them, which will abort processing.
+# Default = False
+ABORT_ON_ERROR = getattr(
+    settings, 'SIDE_EFFECTS_ABORT_ON_ERROR',
+    get_bool('SIDE_EFFECTS_ABORT_ON_ERROR', False)
 )
 
 # In test mode no side-effects are run
+# Default = False
 TEST_MODE = getattr(
     settings, 'SIDE_EFFECTS_TEST_MODE',
     get_bool('SIDE_EFFECTS_TEST_MODE', False)

--- a/tox.ini
+++ b/tox.ini
@@ -9,5 +9,5 @@ deps =
 
 commands=
     coverage erase
-    coverage run --include=side_effects/* manage.py test side_effects
+    coverage run --include=side_effects/* manage.py test side_effects.tests --verbosity=2
     coverage report


### PR DESCRIPTION
This adds a decorator `@disable_side_effects` as well as the context manager that already exists in master. Could do with a second / third pair of eyes on it, as decorators are not my strong point.

It does also move a few things around - and will probably break existing implementations so will bump major version when merged.
