### PR TITLE
Add filter options to to `display_side_effects`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ chdir(path.normpath(path.join(path.abspath(__file__), pardir)))
 
 setup(
     name="django-side-effects",
-    version="1.2",
+    version="1.2.1-dev7",
     packages=find_packages(),
     include_package_data=True,
     description='Django app for managing external side effects.',

--- a/side_effects/management/commands/display_side_effects.py
+++ b/side_effects/management/commands/display_side_effects.py
@@ -20,24 +20,49 @@ class Command(BaseCommand):
             action='store_true',
             help="Display full docstring for all side-effect functions."
         )
+        parser.add_argument(
+            '--label',
+            action='store',
+            dest='label',
+            help="Filter side-effects on a single event label"
+        )
+        parser.add_argument(
+            '--label-contains',
+            action='store',
+            dest='label-contains',
+            help="Filter side-effects on event labels containing the supplied value"
+        )
 
     def handle(self, *args, **options):
-        self.stdout.write("The following side-effects are registered:")
-        if options['raw']:
-            self.print_raw()
-        elif options['verbose']:
-            self.print_verbose()
+        if options['label']:
+            events = _registry.by_label(options['label'])
+            self.stdout.write(
+                f"\nSide-effects for event matching \'{options['label']}\':"
+            )
+        elif options['label-contains']:
+            self.stdout.write(
+                f"\nSide-effects for events matching \'*{options['label-contains']}*\':"
+            )
+            events = _registry.by_label_contains(options['label-contains'])
         else:
-            self.print_default()
+            events = _registry.items()
+            self.stdout.write("\nRegistered side-effects:")
 
-    def print_raw(self):
+        if options['raw']:
+            self.print_raw(events)
+        elif options['verbose']:
+            self.print_verbose(events)
+        else:
+            self.print_default(events)
+
+    def print_raw(self, events):
         """Print out the fully-qualified named for each mapped function."""
-        raw = {label: [fname(f) for f in funcs] for label, funcs in _registry.items()}
+        raw = {label: [fname(f) for f in funcs] for label, funcs in events.items()}
         self.stdout.write(json.dumps(raw, indent=4))
 
-    def print_verbose(self):
+    def print_verbose(self, events):
         """Print the entire docstring for each mapped function."""
-        for label, funcs in _registry.items():
+        for label, funcs in events.items():
             self.stdout.write('')
             self.stdout.write(label)
             self.stdout.write('')
@@ -48,9 +73,9 @@ class Command(BaseCommand):
                     self.stdout.write('    %s' % line)
                 self.stdout.write('')
 
-    def print_default(self):
+    def print_default(self, events):
         """Print the first line of the docstring for each mapped function."""
-        for label, funcs in _registry.items():
+        for label, funcs in events.items():
             self.stdout.write('')
             self.stdout.write(label)
             for func in funcs:

--- a/side_effects/registry.py
+++ b/side_effects/registry.py
@@ -53,6 +53,14 @@ class Registry(defaultdict):
         self._suppress = False
         super(Registry, self).__init__(list)
 
+    def by_label(self, value):
+        """Filter registry by label (exact match)."""
+        return {k:v for k, v in self.items() if k == value}
+
+    def by_label_contains(self, value):
+        """Filter registry by label (contains string)."""
+        return {k:v for k, v in self.items() if value in k}
+
     def contains(self, label, func):
         """
         Lookup label: function mapping in the registry.

--- a/side_effects/tests.py
+++ b/side_effects/tests.py
@@ -127,6 +127,20 @@ class RegistryTests(TestCase):
         r.add('foo', test_func_no_docstring)
         self.assertTrue(r.contains('foo', test_func_no_docstring))
 
+    def test_by_label(self):
+        r = registry.Registry()
+        r.add('foo', test_func_no_docstring)
+        self.assertEqual(r.by_label('foo'), {'foo': [test_func_no_docstring]})
+        self.assertEqual(r.by_label('bar'), {})
+
+    def test_by_label_contains(self):
+        r = registry.Registry()
+        r.add('foo', test_func_no_docstring)
+        self.assertEqual(r.by_label_contains('f'), {'foo': [test_func_no_docstring]})
+        self.assertEqual(r.by_label_contains('fo'), {'foo': [test_func_no_docstring]})
+        self.assertEqual(r.by_label_contains('foo'), {'foo': [test_func_no_docstring]})
+        self.assertEqual(r.by_label_contains('food'), {})
+
 
 class DecoratorTests(TestCase):
 


### PR DESCRIPTION
Fixes #7 

Added a couple of command line options to control the output of `display_side_effects`, by filtering based on the event label.

The current implementation displays all side-effects:

```
$ python manage.py display_side_effects

Registered side-effects:

add_to_cart
  - Update warehouse
  - Notify sales team

add_to_wishlist
  - Notify recipient
  - Update counter

...
```

This PR introduces the option of filtering on an event (exact match):

```
$ python manage.py display_side_effects --label add_to_cart

Side-effects for event matching 'add_to_cart:

add_to_cart
  - Update warehouse
  - Notify sales team
```

Or filtering on events containing some value:

```
$ python manage.py display_side_effects --label-contains add

Side-effects for events matching '*add*:

add_to_cart
  - Update warehouse
  - Notify sales team

add_to_wishlist
  - Notify recipient
  - Update counter
```
