### PR TITLE
Add logging for transaction scopes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ packages = [{ include = "side_effects" }]
 [tool.poetry.dependencies]
 python = "^3.8"
 django = "^3.2 || ^4.0"
-python-env-utils = "*"
 
 [tool.poetry.dev-dependencies]
 black = {version = "*", allow-prereleases = true}

--- a/side_effects/registry.py
+++ b/side_effects/registry.py
@@ -7,6 +7,7 @@ import threading
 from collections import defaultdict
 from typing import Any, Callable, Dict, List
 
+from django.db import transaction
 from django.dispatch import Signal
 
 from . import settings
@@ -192,6 +193,12 @@ def run_side_effects(
     label: str, *args: Any, return_value: Any | None = None, **kwargs: Any
 ) -> None:
     """Run all of the side-effect functions registered for a label."""
+    if not transaction.get_autocommit():
+        getattr(logger, settings.ATOMIC_TX_LOG_LEVEL)(
+            "Side-effects [%s] are being run within the scope of an atomic "
+            "transaction. This may have unintended consequences.",
+            label,
+        )
     _registry.run_side_effects(label, *args, return_value=return_value, **kwargs)
 
 

--- a/side_effects/settings.py
+++ b/side_effects/settings.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 from typing import Any
 
 from django.conf import settings
-from env_utils import get_bool
 
 
 def get_setting(setting_name: str, default_value: Any) -> Any:
-    return getattr(settings, setting_name, get_bool(setting_name, default_value))
+    return getattr(settings, setting_name, default_value)
 
 
 # If True then instead of logging exceptions in side-effects
@@ -24,3 +23,11 @@ TEST_MODE: bool = get_setting("SIDE_EFFECTS_TEST_MODE", False)
 # they shouldn't be.
 # Default = False
 TEST_MODE_FAIL: bool = get_setting("SIDE_EFFECTS_TEST_MODE_FAIL", False)
+
+# Controls the log level to use when warning if side-effects are running
+# inside an atomic transaction. This is not typically the desired
+# behaviour, as it can lead to a failure scenarios in which an exception
+# in an outer function (outside of run_side_effects) causes a tx
+# rollback when the side-effect itself cannot be reverted (e.g. sending
+# email), leaving system in an inconsistent state.
+ATOMIC_TX_LOG_LEVEL: str = get_setting("SIDE_EFFECTS_ATOMIC_TX_LOG_LEVEL", "debug")

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+from django.db import transaction
 from django.test import TestCase
 
 from side_effects import registry, settings
@@ -138,6 +139,24 @@ class RegistryFunctionTests(TestCase):
         registry.register_side_effect("foo", test_func)
         self.assertRaises(
             registry.SideEffectsTestFailure, registry.run_side_effects, "foo"
+        )
+
+    @mock.patch("side_effects.registry.settings.ATOMIC_TX_LOG_LEVEL", "warning")
+    @mock.patch("side_effects.registry.logger")
+    def test_run_side_effects__inside_atomic(self, mock_logger):
+        def test_func():
+            pass
+
+        registry.register_side_effect("foo", test_func)
+
+        # TestCase methods are transactional by default, so this should
+        # always be false - i.e. we are inside a transaction.atomic
+        # scope, and so should be logging a warning.
+        assert transaction.get_autocommit() is False
+        registry.run_side_effects("foo")
+        mock_logger.warning.assert_called_once_with(
+            "Side-effects [%s] are being run within the scope of an atomic "
+            "transaction. This may have unintended consequences.", "foo"
         )
 
     def test__run_func__no_return_value(self):


### PR DESCRIPTION
Running the `run_side_effects` function inside an atomic transaction scope may have unintended consequences - if the outer scope is rolled back then the Django database will be restored to its original state, but side-effects functions will have been run. By their very nature (emails, notifications, external system updates) these functions have non-revertible actions.

Simple scenario - someone receives an order confirmation email, but there is no record of the order ever having been placed. (To say nothing of an external credit card transaction.)

This PR adds a customised logging statement when this situation occurs. By default it logs a "debug" level message, but if you are using an external exception monitoring service you can crank this up to a "warning" or "error" to provide runtime visibility.