### PR TITLE
Ensure that has_side_effects runs on transaction.on_commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.egg-info
 *.lock
 *.pyc
+dist/

--- a/side_effects/decorators.py
+++ b/side_effects/decorators.py
@@ -59,11 +59,16 @@ def has_side_effects(
         def inner_func(*args: Any, **kwargs: Any) -> Any:
             """Run the original function and send the signal if successful."""
             return_value = func(*args, **kwargs)
-            if run_on_exit(return_value):
-                registry.run_side_effects(
-                    label, *args, return_value=return_value, **kwargs
-                )
-            return return_value
+            # if the exit test fails we go no further
+            if not run_on_exit(return_value):
+                return
+
+            registry.run_side_effects_on_commit(
+                label,
+                *args,
+                return_value=return_value,
+                **kwargs,
+            )
 
         return inner_func
 

--- a/side_effects/registry.py
+++ b/side_effects/registry.py
@@ -5,6 +5,7 @@ import inspect
 import logging
 import threading
 from collections import defaultdict
+from functools import partial
 from typing import Any, Callable, Dict, List
 
 from django.db import transaction
@@ -200,6 +201,21 @@ def run_side_effects(
             label,
         )
     _registry.run_side_effects(label, *args, return_value=return_value, **kwargs)
+
+
+def run_side_effects_on_commit(
+    label: str, *args: Any, return_value: Any | None = None, **kwargs: Any
+) -> None:
+    """Run all of the side-effects after current transaction on_commit."""
+    transaction.on_commit(
+        partial(
+            _registry.run_side_effects,
+            label,
+            *args,
+            return_value=return_value,
+            **kwargs,
+        )
+    )
 
 
 def _run_func(

--- a/side_effects/registry.py
+++ b/side_effects/registry.py
@@ -194,12 +194,6 @@ def run_side_effects(
     label: str, *args: Any, return_value: Any | None = None, **kwargs: Any
 ) -> None:
     """Run all of the side-effect functions registered for a label."""
-    if not transaction.get_autocommit():
-        getattr(logger, settings.ATOMIC_TX_LOG_LEVEL)(
-            "Side-effects [%s] are being run within the scope of an atomic "
-            "transaction. This may have unintended consequences.",
-            label,
-        )
     _registry.run_side_effects(label, *args, return_value=return_value, **kwargs)
 
 

--- a/side_effects/settings.py
+++ b/side_effects/settings.py
@@ -23,11 +23,3 @@ TEST_MODE: bool = get_setting("SIDE_EFFECTS_TEST_MODE", False)
 # they shouldn't be.
 # Default = False
 TEST_MODE_FAIL: bool = get_setting("SIDE_EFFECTS_TEST_MODE_FAIL", False)
-
-# Controls the log level to use when warning if side-effects are running
-# inside an atomic transaction. This is not typically the desired
-# behaviour, as it can lead to a failure scenarios in which an exception
-# in an outer function (outside of run_side_effects) causes a tx
-# rollback when the side-effect itself cannot be reverted (e.g. sending
-# email), leaving system in an inconsistent state.
-ATOMIC_TX_LOG_LEVEL: str = get_setting("SIDE_EFFECTS_ATOMIC_TX_LOG_LEVEL", "debug")

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,6 +1,5 @@
 from unittest import mock
 
-from django.db import transaction
 from django.test import TestCase
 
 from side_effects import registry, settings
@@ -139,25 +138,6 @@ class RegistryFunctionTests(TestCase):
         registry.register_side_effect("foo", test_func)
         self.assertRaises(
             registry.SideEffectsTestFailure, registry.run_side_effects, "foo"
-        )
-
-    @mock.patch("side_effects.registry.settings.ATOMIC_TX_LOG_LEVEL", "warning")
-    @mock.patch("side_effects.registry.logger")
-    def test_run_side_effects__inside_atomic(self, mock_logger):
-        def test_func():
-            pass
-
-        registry.register_side_effect("foo", test_func)
-
-        # TestCase methods are transactional by default, so this should
-        # always be false - i.e. we are inside a transaction.atomic
-        # scope, and so should be logging a warning.
-        assert transaction.get_autocommit() is False
-        registry.run_side_effects("foo")
-        mock_logger.warning.assert_called_once_with(
-            "Side-effects [%s] are being run within the scope of an atomic "
-            "transaction. This may have unintended consequences.",
-            "foo",
         )
 
     def test__run_func__no_return_value(self):


### PR DESCRIPTION
Addresses #23 

---

This PR ensures that when a function is decorated with the `has_side_effects` decorator that the call to `run_side_effects` is deferred using the `transaction.on_commit` function so that it will only run once the transaction has committed. (The `transaction.atomic` decorator will only create a new transaction if one does not already exist - otherwise it uses the existing transaction to create a savepoint.) This should prevent a class of errors that occurs when the side-effect is running in different process (e.g. as a job on a queue) but relies on data that the source function is creating within a transaction. In this instance the side-effect would only be invoked once the transaction has been committed, so it can safely assume that the data has been written to the database.

In implementation terms the action that has been deferred is the call to `run_side_effect` - so all of the side-effects for a given source will only be triggered once the transaction that includes the source function (`has_side_effects`) has been committed.

I did think about having it configurable, but I can't think of a reason / use case where this isn't the desired behaviour when using the decorator, and for cases where you *do* want more control, the `run_side_effects` function is still available.

As this PR stands it's super-simple - use the decorator and defer execution, else use `run_side_effects`. (Which is a code smell already - this just enhances that smell).

The example below illustrates the issue.

```python
@transaction.atomic
def consider_planning_propsal():
    print("Considering planning proposal")
    reject_proposal()
    # raising an unhandled Exception inside a transaction will cause it 
    # to rollback, wiping out any changes made to the database in the
    # reject_proposal() function.
    raise Exception("Ignore previous decision - proposal APPROVED")


@has_side_effects("planning_proposal_rejected")
@transaction.atomic
def reject_proposal():
    # The side-effects decorator wraps the transaction decorator which 
    # means that if the function fails the transaction is rolled back
    # and the side-effects never fire, which is the desired outcome. However,
    # if this function is called from another function that is itself inside
    # a transaction, then the `atomic` decorator creates a "savepoint" within
    # the existing transaction rather than creating a new one. This savepoint
    # is controlled by the outer transaction, and if it is rolled back then
    # the savepoint is cleared - having the effect of rolling back any
    # database changes in this function. However, the side-effects will 
    # have already fired, because they only care about the function exiting
    # without error.
    print("Planning consent rejected")
    update_planning_database()


@is_side_effect_of("planning_proposal_rejected")
def irreversible_action():
    print("Demolishing house")
    demolish_house()
```

```python
# BEFORE this PR
>>> consider_planning_proposal()
"Considering planning proposal"
"Planning consent rejected"
"Demolishing house"
Exception: "Ignore previous decision - proposal APPROVED"  # Too late - house is gone.
```

```python
# AFTER this PR
>>> consider_planning_proposal()
"Considering planning proposal"
"Planning consent rejected"
Exception: "Ignore previous decision - proposal APPROVED"
```
