### PR TITLE
Add --sorted option to management command

### DIFF
--- a/tests/test_display_side_effects.py
+++ b/tests/test_display_side_effects.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from django.test import TestCase
+
+from side_effects.management.commands.display_side_effects import sort_events
+
+
+class SortEventsTests(TestCase):
+    def test_sort_events(self) -> None:
+        def handler_zero():
+            """Docstring 0."""
+
+        def handler_one():
+            """Docstring 1."""
+
+        def handler_two():
+            """Docstring 2."""
+
+        events = {
+            "label_2": [handler_zero, handler_one, handler_two],
+            "label_1": [handler_zero, handler_two],
+        }
+
+        sorted_by_function_name = list(
+            sort_events(
+                events,
+                handler_sort_key=lambda handler: handler.__name__,
+            ).items()
+        )
+        assert sorted_by_function_name == [
+            ("label_1", [handler_two, handler_zero]),
+            ("label_2", [handler_one, handler_two, handler_zero]),
+        ]
+
+        sorted_by_docstring = list(
+            sort_events(
+                events,
+                handler_sort_key=lambda handler: handler.__doc__,
+            ).items()
+        )
+        assert sorted_by_docstring == [
+            ("label_1", [handler_zero, handler_two]),
+            ("label_2", [handler_zero, handler_one, handler_two]),
+        ]


### PR DESCRIPTION
Currently the `display_side_effects` management command prints output in
the order of side effect registration (in accordance with Python's dict
ordering rules). If the command output is stored in a repository, this
can make diffs particularly difficult to follow when changes are made
introducing new side effect labels and/or handler functions.

This PR adds a `--sorted` flag to the `display_side_effects` management
command; when set, it sorts the printed side effects by label, and for
each side effect, sorts handlers by their:

*   function path if one of `--verbose` or `--raw` is specified;
*   docstring for default output.
