### PR TITLE
Amend flake8 configuration and type annotations

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,23 +4,38 @@ max-complexity = 8
 # http://flake8.pycqa.org/en/2.5.5/warnings.html#warning-error-codes
 ignore =
   # pydocstyle - docstring conventions (PEP257)
-  D100	# Missing docstring in public module
-  D101	# Missing docstring in public class
-  D102	# Missing docstring in public method
-  D103	# Missing docstring in public function
-  D104	# Missing docstring in public package
-  D105	# Missing docstring in magic method
-  D106	# Missing docstring in public nested class
-  D107	# Missing docstring in __init__
-  D412  # No blank lines allowed between a section header and its content
+  # Missing docstring in public module
+  D100
+  # Missing docstring in public class
+  D101
+  # Missing docstring in public method
+  D102
+  # Missing docstring in public function
+  D103
+  # Missing docstring in public package
+  D104
+  # Missing docstring in magic method
+  D105
+  # Missing docstring in public nested class
+  D106
+  # Missing docstring in __init__
+  D107
+  # No blank lines allowed between a section header and its content
+  D412
   # pycodestyle - style checker (PEP8)
-  W503  # line break before binary operator
+  # line break before binary operator
+  W503
   # the following are ignored in CI using --extend-ignore option:
-  ; D205  # [pydocstyle] 1 blank line required between summary line and description
-  ; D400  # [pydocstyle] First line should end with a period
-  ; D401  # [pydocstyle] First line should be in imperative mood
-  ; S308  # [bandit] Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.
-  ; S703  # [bandit] Potential XSS on mark_safe function.
+  # [pydocstyle] 1 blank line required between summary line and description
+  ; D205
+  # [pydocstyle] First line should end with a period
+  ; D400
+  # [pydocstyle] First line should be in imperative mood
+  ; D401
+  # [bandit] Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.
+  ; S308
+  # [bandit] Potential XSS on mark_safe function.
+  ; S703
 
 per-file-ignores =
   ; D205 - 1 blank line required between summary line and description

--- a/side_effects/checks.py
+++ b/side_effects/checks.py
@@ -40,7 +40,7 @@ def signature_count(label: str) -> int:
 @register()
 def check_function_signatures(app_configs: list[AppConfig], **kwargs: Any) -> list[str]:
     """Check that all registered functions have the same signature."""
-    errors = []  # type: List[str]
+    errors: List[str] = []
     for label in REGISTRY:
         if signature_count(label) > 1:
             errors.append(_message(label))

--- a/side_effects/management/commands/display_side_effects.py
+++ b/side_effects/management/commands/display_side_effects.py
@@ -15,7 +15,7 @@ class Command(BaseCommand):
     help = "Displays project side_effects."
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self.missing_docstrings = []  # type: List[str]
+        self.missing_docstrings: List[str] = []
         super().__init__(*args, **kwargs)
 
     def add_arguments(self, parser: argparse.ArgumentParser) -> None:


### PR DESCRIPTION
Currently the linting checks fail on master (presumably because the
linting library versions are unpinned, and those libraries have been
updated).

1.  Flake8 does not accept inline comments in its configuration (see
    https://flake8.pycqa.org/en/latest/user/configuration.html); this
    commit moves inline comments to their own lines in `.flake8`.
2.  Two `typing.List` imports were flagged as unused because they were
    only used via `# type:` comments. This commit updates them to use
    the `varname: Type` notation instead.
