### PR TITLE
Add optional side_effect_meta parameter

### DIFF
--- a/side_effects/checks.py
+++ b/side_effects/checks.py
@@ -30,11 +30,15 @@ def signature_count(label: str) -> int:
         sig = inspect.signature(func)
         # remove return_value from the signature params as it's dynamic
         # and may/ may not exist depending on the usage.
-        params = [sig.parameters[p] for p in sig.parameters if p != "return_value"]
+        params = [
+            param
+            for param_name, param in sig.parameters.items()
+            if param_name not in ("return_value", "side_effect_meta")
+        ]
         return sig.replace(parameters=params, return_annotation=sig.return_annotation)
 
-    signatures = [trim_signature(func) for func in registry._registry[label]]
-    return len(set(signatures))
+    signatures = {trim_signature(func) for func in registry._registry[label]}
+    return len(signatures)
 
 
 @register()


### PR DESCRIPTION
**Reviewers: this is a _draft_ proposal that would have some utility elsewhere. Any thoughts are welcome.**

Add optional side_effect_meta parameter

In some situations it is useful to know _why_ a side effect handler is
called. We _could_ solve this by also passing in the `label` when a handler
is called, dependent on the signature. Implementation-wise this could be
handled analogously to how the `return_value` is provided, but this
risks ballooning complexity (e.g. in `try_bind_all` and `_run_func`). It
also fails to provide a simple means of adding extra metadata in future.

Instead, this PR adds a single `side_effect_meta` argument, which:

1.  provides a canonical place to add future side effect metadata, and
    currently gives handlers access to the return value _and_ `label`;
2.  co-exists with `return_value`, giving consumers time to switch;
3.  does not pollute `**kwargs`--this restriction is necessary to avoid
    complexity while `return_value` still exists, but also results in
    more predictable behaviour, and keeps `**kwargs` exactly as passed
    to the original function;
4.  _must_ be used as an explicit, keyword-only parameter, preventing
    bugs due to parameter ordering (and clashes with `return_value`);
5.  is more type-safe: it always has type `SideEffectMeta[ReturnValue]`,
    and the behaviour is easier to predict from a function signature.
