### PR TITLE
`__future__.annotations` warning for function signature check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: pyupgrade
 
   # Flake8 includes pyflakes, pycodestyle, mccabe, pydocstyle, bandit
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 3.9.2
     hooks:
       - id: flake8

--- a/side_effects/apps.py
+++ b/side_effects/apps.py
@@ -8,7 +8,6 @@ logger = logging.getLogger(__name__)
 
 
 class SideEffectsConfig(AppConfig):
-
     name = "side_effects"
     verbose_name = "External Side Effects"
 

--- a/side_effects/checks.py
+++ b/side_effects/checks.py
@@ -74,11 +74,11 @@ def find_fixes(label: str) -> messages.CheckMessage | None:
     functions = [func for func in registry._registry[label]]
     signatures = [trim_signature(func) for func in functions]
     if len(set(signatures)) > 1:
-
         if has_class_annotations(functions) and annotations:
             return _message_annotations(label)
         else:
             return _message(label)
+    return None
 
 
 @register()

--- a/side_effects/checks.py
+++ b/side_effects/checks.py
@@ -25,6 +25,7 @@ def _message(label: str) -> messages.CheckMessage:
     )
     return messages.Warning(msg, hint=hint, id=CHECK_ID_MULTIPLE_SIGNATURES)
 
+
 def _message_annotations(label: str) -> messages.CheckMessage:
     """
     Message printed if file missing __future__.annotations.
@@ -35,7 +36,7 @@ def _message_annotations(label: str) -> messages.CheckMessage:
     hint = (
         f"Ensure that all files with functions decorated "
         f'`@is_side_effect_of("{label}")` import'
-        f'`from __future__ import annotations`.'
+        f"`from __future__ import annotations`."
     )
     return messages.Warning(msg, hint=hint, id=CHECK_ID_NO_ANNOTATIONS)
 
@@ -48,7 +49,8 @@ def trim_signature(func: Callable) -> inspect.Signature:
     params = [sig.parameters[p] for p in sig.parameters if p != "return_value"]
     return sig.replace(parameters=params, return_annotation=sig.return_annotation)
 
-def has_class_annotations(functions: List[Callable]) -> bool:
+
+def has_class_annotations(functions: list[Callable]) -> bool:
     """
     Check if functions have class annotations.
     If any function annotations are not in string format, this will return `True`.
@@ -59,6 +61,7 @@ def has_class_annotations(functions: List[Callable]) -> bool:
             if not annotation in [str, None]:
                 return True
     return False
+
 
 def find_fixes(label: str) -> messages.CheckMessage | None:
     """
@@ -72,10 +75,11 @@ def find_fixes(label: str) -> messages.CheckMessage | None:
         else:
             return _message(label)
 
+
 @register()
 def check_function_signatures(app_configs: list[AppConfig], **kwargs: Any) -> list[str]:
     """Check that all registered functions have the same signature."""
-    errors: List[str] = []
+    errors: list[str] = []
     for label in REGISTRY:
         if error := find_fixes(label):
             errors.append(error)

--- a/side_effects/checks.py
+++ b/side_effects/checks.py
@@ -10,10 +10,14 @@ from . import registry
 
 REGISTRY = registry._registry
 CHECK_ID_MULTIPLE_SIGNATURES = "side_effects.W001"
+CHECK_ID_NO_ANNOTATIONS = "side_effects.W002"
 
 
 def _message(label: str) -> messages.CheckMessage:
-    """Create Error or Warning message based on STRICT_MODE."""
+    """
+    Message printed if varying function signatures for same event.
+
+    Create Error or Warning message based on STRICT_MODE."""
     msg = f'Multiple function signatures for event: "{label}"'
     hint = (
         f"Ensure that all functions decorated "
@@ -21,27 +25,58 @@ def _message(label: str) -> messages.CheckMessage:
     )
     return messages.Warning(msg, hint=hint, id=CHECK_ID_MULTIPLE_SIGNATURES)
 
+def _message_annotations(label: str) -> messages.CheckMessage:
+    """
+    Message printed if file missing __future__.annotations.
 
-def signature_count(label: str) -> int:
-    """Return number of unique function signatures for an event."""
+    Create Error or Warning message based on STRICT_MODE.
+    """
+    msg = f'Files with functions for event "{label}" missing __future__.annotations'
+    hint = (
+        f"Ensure that all files with functions decorated "
+        f'`@is_side_effect_of("{label}")` import'
+        f'`from __future__ import annotations`.'
+    )
+    return messages.Warning(msg, hint=hint, id=CHECK_ID_NO_ANNOTATIONS)
 
-    def trim_signature(func: Callable) -> inspect.Signature:
-        # Return a Signature for the func that ignores return_value kwarg
-        sig = inspect.signature(func)
-        # remove return_value from the signature params as it's dynamic
-        # and may/ may not exist depending on the usage.
-        params = [sig.parameters[p] for p in sig.parameters if p != "return_value"]
-        return sig.replace(parameters=params, return_annotation=sig.return_annotation)
 
-    signatures = [trim_signature(func) for func in registry._registry[label]]
-    return len(set(signatures))
+def trim_signature(func: Callable) -> inspect.Signature:
+    # Return a Signature for the func that ignores return_value kwarg
+    sig = inspect.signature(func)
+    # remove return_value from the signature params as it's dynamic
+    # and may/ may not exist depending on the usage.
+    params = [sig.parameters[p] for p in sig.parameters if p != "return_value"]
+    return sig.replace(parameters=params, return_annotation=sig.return_annotation)
 
+def has_class_annotations(functions: List[Callable]) -> bool:
+    """
+    Check if functions have class annotations.
+    If any function annotations are not in string format, this will return `True`.
+    """
+    for func in functions:
+        func_annotations = list(inspect.get_annotations(func).values())
+        for annotation in func_annotations:
+            if not annotation in [str, None]:
+                return True
+    return False
+
+def find_fixes(label: str) -> messages.CheckMessage | None:
+    """
+    Check for similar function signatures, and returns a fix if found.
+    """
+    functions = [func for func in registry._registry[label]]
+    signatures = [trim_signature(func) for func in functions]
+    if len(set(signatures)) > 1:
+        if has_class_annotations(functions):
+            return _message_annotations(label)
+        else:
+            return _message(label)
 
 @register()
 def check_function_signatures(app_configs: list[AppConfig], **kwargs: Any) -> list[str]:
     """Check that all registered functions have the same signature."""
     errors: List[str] = []
     for label in REGISTRY:
-        if signature_count(label) > 1:
-            errors.append(_message(label))
+        if error := find_fixes(label):
+            errors.append(error)
     return errors

--- a/side_effects/management/commands/display_side_effects.py
+++ b/side_effects/management/commands/display_side_effects.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
-from typing import Any, Callable, List
+from typing import Any, Callable
 
 from django.core.management.base import BaseCommand
 
@@ -31,11 +31,10 @@ def sort_events(
 
 
 class Command(BaseCommand):
-
     help = "Displays project side_effects."
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self.missing_docstrings: List[str] = []
+        self.missing_docstrings: list[str] = []
         super().__init__(*args, **kwargs)
 
     def add_arguments(self, parser: argparse.ArgumentParser) -> None:

--- a/tests/fixtures/checks_fixtures.py
+++ b/tests/fixtures/checks_fixtures.py
@@ -1,0 +1,5 @@
+class Goo:
+    pass
+
+def gar(arg1: Goo):
+    pass

--- a/tests/fixtures/checks_fixtures.py
+++ b/tests/fixtures/checks_fixtures.py
@@ -1,5 +1,6 @@
 class Goo:
     pass
 
+
 def gar(arg1: Goo):
     pass

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
 from django.test import TestCase
 
 from side_effects import checks, registry
-
+from .fixtures.checks_fixtures import Goo, gar
 
 class SystemCheckTests(TestCase):
     def test_multiple_functions(self):
@@ -23,3 +24,15 @@ class SystemCheckTests(TestCase):
         errors = checks.check_function_signatures(None)
         self.assertEqual(len(errors), 1)
         self.assertEqual(errors[0].id, checks.CHECK_ID_MULTIPLE_SIGNATURES)
+
+    def test_similar_functions(self):
+        def foo(arg1: Goo):
+            pass
+
+        registry._registry.clear()
+        registry.register_side_effect("test", foo)
+        registry.register_side_effect("test", gar)
+
+        errors = checks.check_function_signatures(None)
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0].id, checks.CHECK_ID_NO_ANNOTATIONS)


### PR DESCRIPTION
## Summary

The function signature checker will throw a specific warning about files missing `from __future__ import annotations` if there's a signature mismatch between functions.

## Why is this change being made

This library requires all functions decorated by a side effect to have the same signature. If the signature does not match, an error is raised.

If there is one file without the `__future__.annotations` import, the signatures will look identical, but the checker will still raise an error. This is because it will be comparing a string (where `annotations` was imported) to a class (where it wasn't). 

The code below differentiates between a missing `from __future__ import annotations` on a file, and a different signature by throwing a different error in either case.

Explaining why the signature does not match will help developers fix future issues faster.