### PR TITLE
Django 5.2 upgrades.

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -61,19 +61,19 @@ jobs:
     strategy:
       matrix:
         python: ["3.9", "3.10", "3.11", "3.12"]
-        # build LTS version, next version, HEAD
-        django: ["32", "42", "50", "main"]
+        # build LTS version, current version, next version, HEAD
+        django: ["42", "50", "52", "main"]
         exclude:
           - python: "3.9"
             django: "50"
+          - python: "3.9"
+            django: "52"
           - python: "3.9"
             django: "main"
           - python: "3.10"
             django: "main"
           - python: "3.11"
-            django: "32"
-          - python: "3.12"
-            django: "32"
+            django: "main"
 
     env:
       TOXENV: django${{ matrix.django }}-py${{ matrix.python }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
+  - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: "v0.2.1"
+    rev: "v0.3.0"
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## 3.1.0 - 2024-08-11
+
+- Add Django 5.2 compatibility
+- Drop support for Django versions before 4.2
+- Update ruff commands to use modern "ruff check" syntax
+- Update GitHub workflows to test Django main branch only with Python 3.12+
+
 ## 3.0 - 2024-02-12
 
 - Refactor internals to fix transaction handling

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Django app for managing external side effects.
 
 ## Compatibility
 
-**This project now supports Python 3.8+ and Django 3.2+ only on master.**
+**This project now supports Python 3.9+ and Django 4.2+ only on master.**
 
 Legacy versions are tagged.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-side-effects"
-version = "3.0.1"
+version = "3.1.0"
 description = "Django app for managing external side effects."
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]
@@ -10,11 +10,9 @@ homepage = "https://github.com/yunojuno/django-side-effects"
 repository = "https://github.com/yunojuno/django-side-effects"
 classifiers = [
     "Environment :: Web Environment",
-    "Framework :: Django :: 3.2",
-    "Framework :: Django :: 4.0",
-    "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.2",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.9",
@@ -26,7 +24,7 @@ packages = [{ include = "side_effects" }]
 
 [tool.poetry.dependencies]
 python = "^3.9"
-django = "^3.2 || ^4.0 || ^5.0 "
+django = "^4.2 || ^5.0 || ^5.2"
 
 [tool.poetry.dev-dependencies]
 coverage = "*"

--- a/side_effects/registry.py
+++ b/side_effects/registry.py
@@ -1,4 +1,5 @@
 """Registry is responsible for managing all of the registered side-effects."""
+
 from __future__ import annotations
 
 import inspect

--- a/tox.ini
+++ b/tox.ini
@@ -3,13 +3,11 @@ isolated_build = True
 envlist =
     fmt, lint, mypy,
     django-checks,
-    ; https://docs.djangoproject.com/en/5.0/releases/
-    django32-py{39,310}
-    django40-py{39,310}
-    django41-py{39,310,311}
+    ; https://docs.djangoproject.com/en/5.2/releases/
     django42-py{39,310,311}
     django50-py{310,311,312}
-    djangomain-py{311,312}
+    django52-py{310,311,312}
+    djangomain-py312
 
 [testenv]
 deps =
@@ -17,11 +15,9 @@ deps =
     pytest
     pytest-cov
     pytest-django
-    django32: Django>=3.2,<3.3
-    django40: Django>=4.0,<4.1
-    django41: Django>=4.1,<4.2
     django42: Django>=4.2,<4.3
-    django50: https://github.com/django/django/archive/stable/5.0.x.tar.gz
+    django50: Django>=5.0,<5.1
+    django52: https://github.com/django/django/archive/stable/5.2.x.tar.gz
     djangomain: https://github.com/django/django/archive/main.tar.gz
 
 commands =
@@ -48,7 +44,7 @@ deps =
     ruff
 
 commands =
-    ruff side_effects
+    ruff check side_effects
 
 [testenv:mypy]
 description = Python source code type hints (mypy)


### PR DESCRIPTION
# Add Django 5.2 Compatibility

## Changes

This PR includes several updates to maintain compatibility with modern Django/Python versions and improve the project's configuration:

- **Django Compatibility**:
  - Added support for Django 5.2
  - Dropped support for Django versions before 4.2 (3.2, 4.0, 4.1)
  - Updated classifiers in `pyproject.toml`

- **Python Compatibility**:
  - Maintained support for Python 3.9+
  - Configured Django main branch to only test with Python 3.12

- **Tooling Updates**:
  - Updated ruff commands to use modern "ruff check` syntax
  - Updated ruff pre-commit hooks to use the latest version from the astral-sh repository
  - Simplified tox configuration to focus on supported versions

- **Documentation**:
  - Updated `README` compatibility section
  - Updated `CHANGELOG` with version 3.1.0 details

## Motivation

This PR ensures that the project is made compatible for Django 5.2. At the same time, this is a good opportunity to remove support for older Django versions that we have taken the decision to discontinue support for.

The changes are minimal and focused on compatibility, with no functional changes to the code itself.