### PR TITLE
Add Django 6.0, Python 3.13 support

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -22,10 +22,10 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v4
 
-      - name: Set up Python (3.11)
+      - name: Set up Python (3.12)
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install and run tox
         run: |
@@ -45,10 +45,10 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v4
 
-      - name: Set up Python (3.11)
+      - name: Set up Python (3.12)
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install and run tox
         run: |
@@ -60,20 +60,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.9", "3.10", "3.11", "3.12"]
-        # build LTS version, current version, next version, HEAD
-        django: ["42", "50", "52", "main"]
-        exclude:
-          - python: "3.9"
-            django: "50"
-          - python: "3.9"
-            django: "52"
-          - python: "3.9"
-            django: "main"
-          - python: "3.10"
-            django: "main"
-          - python: "3.11"
-            django: "main"
+        python: ["3.12", "3.13"]
+        django: ["52", "60", "main"]
 
     env:
       TOXENV: django${{ matrix.django }}-py${{ matrix.python }}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Django app for managing external side effects.
 
 ## Compatibility
 
-**This project now supports Python 3.9+ and Django 4.2+ only on master.**
+**This project now supports Python 3.12+ and Django 5.2-6.0 only on master.**
 
 Legacy versions are tagged.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-side-effects"
-version = "3.1.0"
+version = "3.2.0"
 description = "Django app for managing external side effects."
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]
@@ -10,23 +10,20 @@ homepage = "https://github.com/yunojuno/django-side-effects"
 repository = "https://github.com/yunojuno/django-side-effects"
 classifiers = [
     "Environment :: Web Environment",
-    "Framework :: Django :: 4.2",
-    "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.2",
+    "Framework :: Django :: 6.0",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 packages = [{ include = "side_effects" }]
 
 [tool.poetry.dependencies]
-python = "^3.9"
-django = "^4.2 || ^5.0 || ^5.2"
+python = "^3.12"
+django = ">=5.2,<7.0"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 coverage = "*"
 mypy = "*"
 pre-commit = "*"

--- a/side_effects/registry.py
+++ b/side_effects/registry.py
@@ -60,7 +60,6 @@ class Registry(defaultdict):
     # if using the disable_side_effects context manager or decorator,
     # then this signal is used to communicate details of events that
     # would have fired, but have been suppressed.
-    # RemovedInDjango40Warning: providing_args=["label"]
     suppressed_side_effect = Signal()
 
     def __init__(self) -> None:

--- a/side_effects/signals.py
+++ b/side_effects/signals.py
@@ -3,5 +3,4 @@ from django.dispatch import Signal
 # if using the disable_side_effects context manager or decorator,
 # then this signal is used to communicate details of events that
 # would have fired, but have been suppressed.
-# RemovedInDjango40Warning: providing_args=["label"]
 suppressed_side_effect = Signal()

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,9 @@ isolated_build = True
 envlist =
     fmt, lint, mypy,
     django-checks,
-    ; https://docs.djangoproject.com/en/5.2/releases/
-    django42-py{39,310,311}
-    django50-py{310,311,312}
-    django52-py{310,311,312}
-    djangomain-py312
+    django52-py{312,313}
+    django60-py{312,313}
+    djangomain-py{312,313}
 
 [testenv]
 deps =
@@ -15,9 +13,8 @@ deps =
     pytest
     pytest-cov
     pytest-django
-    django42: Django>=4.2,<4.3
-    django50: Django>=5.0,<5.1
-    django52: https://github.com/django/django/archive/stable/5.2.x.tar.gz
+    django52: Django>=5.2,<5.3
+    django60: Django>=6.0,<6.1
     djangomain: https://github.com/django/django/archive/main.tar.gz
 
 commands =


### PR DESCRIPTION
## Summary

This PR upgrades the package to support Django 6.0 and Python 3.13.

## Changes

### Added
  - ✅ Django 6.0 support
  - ✅ Python 3.12, 3.13 support

### Removed
  - ❌ Python 3.9, 3.10, 3.11 support (now requires Python 3.12+)
  - ❌ Django 4.2 and 5.0 support (now supports Django 5.2-6.0)